### PR TITLE
fix map_at_k (unsorted topk to sorted)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 from os import path
 
-VERSION = '0.2.12'
+VERSION = '0.2.13'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/test/test_retrieval_evaluators.py
+++ b/test/test_retrieval_evaluators.py
@@ -108,7 +108,8 @@ class TestInformationRetrievalMetrics(unittest.TestCase):
                    np.array([[1, 0, 1, 1]]),
                    np.array([[1, 0, 1, 1]]),
                    np.array([[0, 0, 0, 0]]),
-                   np.array([[1, 0, 1]])]
+                   np.array([[1, 0, 1]]),
+                   np.array([[1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1]])]
         predictions = [np.array([[5, 4, 3, 2],
                                  [5, 4, 3, 2]]),
                        np.array([[5, 4, 3, 2]]),
@@ -121,9 +122,10 @@ class TestInformationRetrievalMetrics(unittest.TestCase):
                        np.array([[2, 3, 5, 4]]),
                        np.array([[2, 3, 5, 4]]),
                        np.array([[2, 3, 5, 4]]),
-                       np.array([[2, 3, 5]])]
-        rank = [4, 4, 4, 4, 4, 4, 3, 3, 5, 2, 4, 4]
-        expectations = [0.77777, 0.80555, 0.75, 0.0, 0.91666, 1.0, 1.0, 0.66666, 0.91666, 1.0, 0.0, 0.83333]
+                       np.array([[2, 3, 5]]),
+                       np.array([[2, 3, 5, 4, 2, 3, 5, 4, 2, 3, 5, 4, 2, 3, 5, 7, 3, 4]])]
+        rank = [4, 4, 4, 4, 4, 4, 3, 3, 5, 2, 4, 4, 8]
+        expectations = [0.77777, 0.80555, 0.75, 0.0, 0.91666, 1.0, 1.0, 0.66666, 0.91666, 1.0, 0.0, 0.83333, 0.61339]
 
         assert len(targets) == len(predictions) == len(rank) == len(expectations)
 

--- a/vision_evaluation/evaluators.py
+++ b/vision_evaluation/evaluators.py
@@ -1063,7 +1063,7 @@ class L1ErrorEvaluator(MattingEvaluatorBase):
         for pred_mask, gt_mask in zip(predictions, targets):
             pred_mask = np.asarray(pred_mask)
             gt_mask = np.asarray(gt_mask)
-            mean_l1 = np.abs(pred_mask.astype(np.float)-gt_mask.astype(np.float)).mean()
+            mean_l1 = np.abs(pred_mask.astype(float)-gt_mask.astype(float)).mean()
             self._metric_sum += mean_l1
 
 

--- a/vision_evaluation/retrieval_evaluators.py
+++ b/vision_evaluation/retrieval_evaluators.py
@@ -115,9 +115,10 @@ class MeanAveragePrecisionAtK(RetrievalEvaluator):
         if total_pos_gt == 0:
             return 0.0
         rank = min(self.k, len(predictions))
-        top_k_pred_indices = np.argpartition(-predictions, rank - 1)[:rank]
+        top_k_pred_indices_unsorted = np.argpartition(-predictions, rank - 1)[:rank]  # get indices of topk
+        top_k_pred_indices_sorted = top_k_pred_indices_unsorted[np.argsort(-predictions[top_k_pred_indices_unsorted])]  # sort topk and get their indices
         # sort score, gt by top_k
-        targets = targets[top_k_pred_indices]
+        targets = targets[top_k_pred_indices_sorted]
         sum = 0.0
         num_hits = 0.0
         for idx, tgt in enumerate(targets):


### PR DESCRIPTION
map@k requires predictions to be sorted, which was not the case before this PR. This PR rectifies this issue