### PR TITLE
Make pycococap package optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ While different machine learning problems/applications prefer different metrics,
 
 ## Additional Requirements
 
-The image caption evaluators requires Jave Runtime Environment (JRE) (Java 1.8.0). This is not required for other evaluators.
+The image caption evaluators requires Jave Runtime Environment (JRE) (Java 1.8.0) and some extra dependencies which can be installed with `pip install vision-evaluation[caption]`. This is not required for other evaluators.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ setuptools.setup(name='vision-evaluation',
                      'numpy',
                      'scikit-learn>=1.0',
                      'pycocotools',
-                     'pycocoevalcap',
                      'opencv-python-headless',
                      'Pillow>=6.2.2'
-                 ])
+                 ],
+                 extras_require={
+                     'caption': ['pycocoevalcap']
+                 })


### PR DESCRIPTION
This package is not updated for long time and we cannot use it on our production.